### PR TITLE
Automated the build of the PG server

### DIFF
--- a/.scripts/bicep-vm/virtual-machines/general/vm-small/vm-small.bicep
+++ b/.scripts/bicep-vm/virtual-machines/general/vm-small/vm-small.bicep
@@ -10,6 +10,7 @@ param password string
 param OSPublisher string
 param OSOffer string
 param privateIPAddress string
+param customData string
 
 var vmName = namePrefix
 
@@ -52,6 +53,7 @@ resource vm_small 'Microsoft.Compute/virtualMachines@2019-07-01' = {
       computerName: vmName
       adminUsername: username
       adminPassword: password
+      customData: customData
     }
     networkProfile: {
       networkInterfaces: [

--- a/.scripts/bicep-vm/virtual-machines/vm-lab/vm-lab.bicep
+++ b/.scripts/bicep-vm/virtual-machines/vm-lab/vm-lab.bicep
@@ -20,6 +20,7 @@ module vm_pgsql '../general/vm-small/vm-small.bicep' = {
     username: username
     password: password
     privateIPAddress:  '10.1.0.4'
+    customData: ''
   }
 }
 

--- a/.scripts/bicep-vm/virtual-machines/vm-postgresql/bootstrap.sh
+++ b/.scripts/bicep-vm/virtual-machines/vm-postgresql/bootstrap.sh
@@ -22,8 +22,17 @@ EOF
 
 systemctl status wildfly
 
-# NEED TO SETUP WILDFLY ADMIN user HERE
+##############
+# HARDCODED ADMIN PASSWORD! DO NOT USE IN ANYTHING RESEMBLING PRODUCTION!!!!
+# FOR DEMO/WORKSHOP PURPOSES ONLY!!!! 
+##############
+/opt/wildfly/bin/add-user.sh -u 'adminuser1' -p 'password1!' -g 'admin'
+##############
+# YOU HAVE BEEN WARNED
+##############
+
 # Change Wildfly standalone.sh to accept input from 0.0.0.0
+sed -i 's#$WILDFLY_HOME/bin/standalone.sh -c $2 -b $3#$WILDFLY_HOME/bin/standalone.sh -c $2 -b $3 -bmanagement=0.0.0.0#g' /opt/wildfly/bin/launch.sh
 
 systemctl restart wildfly
 
@@ -35,8 +44,26 @@ sudo postgresql-setup --initdb
 sudo systemctl start postgresql
 sudo systemctl enable postgresql
 
-# NEED TO CHANGE pg_hba.conf to listen on all addresses for IPv4
+##############
+# HARDCODED POSTGRESS ALLOW ALL HOST BASED AUTH! DO NOT USE IN ANYTHING RESEMBLING PRODUCTION!!!!
+# FOR DEMO/WORKSHOP PURPOSES ONLY!!!! 
+##############
+sed -i 's#local   all             all                                     ident#local   all             all                                     trust#g' /var/lib/pgsql/data/pg_hba.conf
+sed -i 's#host    all             all             127.0.0.1/32            ident#host    all             all             0.0.0.0/0               password#g' /var/lib/pgsql/data/pg_hba.conf
+##############
+# YOU HAVE BEEN WARNED (Again)
+##############
+
+
+# Need to change the postgresql.conf to listen on all addresses too
+sed -i 's|#listen_addresses|listen_addresses|g' /var/lib/pgsql/data/postgresql.conf
+
 
 sudo systemctl restart postgresql
 
 # Need to setup password for PGUser
+cp /root/SetPostgresUserAccountPassword.sql /var/lib/pgsql
+cd /var/lib/pgsql
+chmod u+r SetPostgresUserAccountPassword.sql
+chown postgres:postgres SetPostgresUserAccountPassword.sql
+sudo -u postgres psql -U postgres postgres -f /var/lib/pgsql/SetPostgresUserAccountPassword.sql

--- a/.scripts/bicep-vm/virtual-machines/vm-postgresql/bootstrap.sh
+++ b/.scripts/bicep-vm/virtual-machines/vm-postgresql/bootstrap.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+export WILDFLY_RELEASE="25.0.1"
+wget https://github.com/wildfly/wildfly/releases/download/25.0.1.Final/wildfly-25.0.1.Final.tar.gz
+tar xvf wildfly-$WILDFLY_RELEASE.Final.tar.gz
+mv wildfly-25.0.1.Final /opt/wildfly
+sudo groupadd --system wildfly
+sudo useradd -s /sbin/nologin --system -d /opt/wildfly  -g wildfly wildfly
+sudo mkdir /etc/wildfly
+sudo cp /opt/wildfly/docs/contrib/scripts/systemd/wildfly.conf /etc/wildfly/
+sudo cp /opt/wildfly/docs/contrib/scripts/systemd/wildfly.service /etc/systemd/system/
+sudo cp /opt/wildfly/docs/contrib/scripts/systemd/launch.sh /opt/wildfly/bin/
+sudo chmod +x /opt/wildfly/bin/launch.sh
+sudo chown -R wildfly:wildfly /opt/wildfly
+sudo systemctl daemon-reload
+sudo restorecon -Rv /opt/wildfly/bin/
+setenforce 0
+
+cat >> ~/.bashrc <<EOF
+export WildFly_BIN="/opt/wildfly/bin/"
+export PATH=\$PATH:/opt/wildfly/bin/
+EOF
+
+systemctl status wildfly
+
+# NEED TO SETUP WILDFLY ADMIN user HERE
+# Change Wildfly standalone.sh to accept input from 0.0.0.0
+
+systemctl restart wildfly
+
+sudo dnf -qy module disable postgresql
+sudo dnf -qy module enable postgresql:12
+sudo dnf -y install postgresql-server
+sudo dnf -y install postgresql-contrib
+sudo postgresql-setup --initdb
+sudo systemctl start postgresql
+sudo systemctl enable postgresql
+
+# NEED TO CHANGE pg_hba.conf to listen on all addresses for IPv4
+
+sudo systemctl restart postgresql
+
+# Need to setup password for PGUser

--- a/.scripts/bicep-vm/virtual-machines/vm-postgresql/custom-data.txt
+++ b/.scripts/bicep-vm/virtual-machines/vm-postgresql/custom-data.txt
@@ -5,7 +5,7 @@ packages:
     - wget
 runcmd:
     - cd /root
-    - wget https://gist.githubusercontent.com/Sam-Rowe/1c4793e1e1ed865302b677f7df684c4f/raw/d3c41f888a3376476500ef1f422f76c5afe68754/WildflyBootstrap.sh
+    - wget https://gist.githubusercontent.com/Sam-Rowe/1c4793e1e1ed865302b677f7df684c4f/raw/37c3ed0987cb98cd207aa55e1f4bbe338ee036cb/WildflyBootstrap.sh
     - wget https://gist.githubusercontent.com/Sam-Rowe/50497dab992d6bc7a88bcb50828550ae/raw/b93d6ed9abafa7a183ac19bedf9c43f9a3e1bf19/SetPostgresUserAccountPassword.sql
     - sudo bash WildflyBootstrap.sh 
     - cat "Hello this has run the cmd at the end of the cloud init script" >> hello.md

--- a/.scripts/bicep-vm/virtual-machines/vm-postgresql/custom-data.txt
+++ b/.scripts/bicep-vm/virtual-machines/vm-postgresql/custom-data.txt
@@ -1,0 +1,11 @@
+#cloud-config
+package_upgrade: true
+packages:
+    - java-1.8.0-openjdk-devel
+    - wget
+runcmd:
+    - cd /root
+    - wget https://gist.githubusercontent.com/Sam-Rowe/1c4793e1e1ed865302b677f7df684c4f/raw/d3c41f888a3376476500ef1f422f76c5afe68754/WildflyBootstrap.sh
+    - wget https://gist.githubusercontent.com/Sam-Rowe/50497dab992d6bc7a88bcb50828550ae/raw/b93d6ed9abafa7a183ac19bedf9c43f9a3e1bf19/SetPostgresUserAccountPassword.sql
+    - sudo bash WildflyBootstrap.sh 
+    - cat "Hello this has run the cmd at the end of the cloud init script" >> hello.md

--- a/.scripts/bicep-vm/virtual-machines/vm-postgresql/vm-postgresql.bicep
+++ b/.scripts/bicep-vm/virtual-machines/vm-postgresql/vm-postgresql.bicep
@@ -20,6 +20,7 @@ module vm_pgsql '../general/vm-small/vm-small.bicep' = {
     username: username
     password: password    
     privateIPAddress:  '10.2.0.4'
+    customData: loadFileAsBase64('custom-data.txt')
   }
 }
 


### PR DESCRIPTION
This pull request automates the PG server build. 

Basically skipping the steps to install Widfly and Postgres so the workshop participant starts at the point of installing the war file and setting up the JNDI datastore via the Widlfly Admin portal.

I have hard coded some usernames/passwords for simplicity. They are pointed out in the script and in the docs. 

Also updated the docs to reflect the shortened nature of step 01 building the source PG server with Wildfly.